### PR TITLE
Fix logo position for mobile

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,7 +9,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-left" href="/">
+        <a class="navbar-brand" href="/">
           <img src="/images/devICT-Logo.svg" alt="devICT" class="logo" />
         </a>
       </div>

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -7,10 +7,6 @@ body {
     background:url("/images/cream_pixels.png") top center repeat #FFF;
 }
 
-.logo {
-  height: 3em;
-}
-
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   font-family: 'Oswald', sans-serif;
   font-weight:normal;
@@ -123,7 +119,7 @@ ul#all-tags li {
 
 
 /**
- * Design Things 
+ * Design Things
  */
 
 .navbar-default {
@@ -201,9 +197,13 @@ h2 .fa {padding-right: 10px;}
 .logo {
     width: 170px;
     height: auto;
-    line-height: 3em;
-    padding-top: 5px;
-    padding-bottom: 5px;
+    display: block;
+}
+
+.navbar-brand {
+  padding-top: 5px;
+  padding-bottom: 5px;
+  height: auto;
 }
 
 /*#binary-reader-table .hole span {*/


### PR DESCRIPTION
The logo jumps to the far left of the page on the mobile breakpoint. This should fix it.
