### PR TITLE
Add piwik connection tag. See pull request for discussion.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -27,3 +27,18 @@
 <meta name="theme-color" content="#eb7e32">
 
 <title> {{ .Title }} &middot; {{ .Site.Title }} </title>
+<!-- Piwik -->
+<script type="text/javascript">
+  var _paq = _paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//devict-piwik.ekpyroticfrood.net/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', '1']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Piwik Code -->


### PR DESCRIPTION
In Issue https://github.com/devict/devict.org/issues/24 the idea of adding analytics was mentioned.

Piwik has to run on a web server, so I set up a copy on my own Dreamhost server at
https://devict-piwik.ekpyroticfrood.net/

I can pass on the username and password and any other connection info you want like the SSH account to edit the code on the site.

This PR is to add the required JavaScript to the headers to make this work.

I understand if you don't want to accept this since it is all on my personal hosting, but if you want to try it, here it is.