### PR TITLE
Only show one of each upcoming event on the Events page.

### DIFF
--- a/static/js/events.js
+++ b/static/js/events.js
@@ -1,5 +1,6 @@
 $(function(){
 	var results = $("#results");
+	var eventNamesAlreadySeen = [];
 	results.empty();
     $.ajax({
         url : 'https://devict-proxy.herokuapp.com/events',
@@ -16,7 +17,10 @@ $(function(){
           t.find(".event_venue_city").text(item.venue.city);
           t.find(".event_map").attr("href", 'https://www.google.com/maps/@' + item.venue.lat + ',' + item.venue.lon + ',18z');
           t.find(".event_time").text(epochConv(item.time));
-          results.append(t[0]);
+          if (eventNamesAlreadySeen.indexOf(item.name) === -1) {
+            eventNamesAlreadySeen.push(item.name);
+            results.append(t[0]);
+          }
         }
         catch(err) {
           console.log(err);


### PR DESCRIPTION
This is an unrequested feature to skip all duplicate event names.
This way you only see the closest upcoming entry of any given event.
I don't know if it is a good idea or not. I don't like seeing the
duplicaduplicate
events, because I find it hard to tell which are different and which
are duplicates, but that is just me.
Another idea would be to maybe show a less detailed view for the
duplicatduplicates,
like leave out the description and make the duplicates smaller.

Let me know what you think and I can tweak this, or just reject it if you don't like the idea.