### PR TITLE
Fix extra padding under nav item when hovered on

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -219,7 +219,7 @@ h2 .fa {padding-right: 10px;}
 }
 
 .logo {
-    width: 170px;
+    width: 160px;
     height: auto;
     display: block;
 }


### PR DESCRIPTION
This is really small but it was driving me crazy, lol. The only problem with the solution is it makes the logo in the top bar 10px smaller. It's honestly not really noticeable, but it's something to consider. It does however remove the extra white padding under nav items when hovered on. Unless that is intentional by design?

_extra black on top of 1st image is just bad cropping of screenshot_

Before:

<img width="1280" alt="screen shot 2017-10-31 at 8 29 00 pm" src="https://user-images.githubusercontent.com/6027057/32256109-1f46e708-be7b-11e7-8b97-644e244cda7d.png">


After:

<img width="1278" alt="screen shot 2017-10-31 at 8 28 30 pm" src="https://user-images.githubusercontent.com/6027057/32256124-2872b5c8-be7b-11e7-9880-763a9281bca3.png">
