### PR TITLE
Namespace dev survey modal styles

### DIFF
--- a/static/css/modal.css
+++ b/static/css/modal.css
@@ -1,6 +1,6 @@
 /*Plain CSS*/
 
-.modal {
+.survey-modal {
     position: fixed;
     opacity: 0;
     display: table;
@@ -10,15 +10,15 @@
     left: 0;
     z-index: 5000;
 }
-.modal.fade .modal-inner {
+.survey-modal.fade .survey-modal-inner {
     transform: translateY(-100px);
     transition: all .3s ease-in-out;
 }
-.modal.fade.in {
+.survey-modal.fade.in {
     opacity: 1;
     transition: all .3s ease-in-out;
 }
-.modal.fade.in .modal-inner {
+.survey-modal.fade.in .survey-modal-inner {
     transform: translateY(0);
     height: auto;
     box-shadow: 0 2px 3px 0 #303030;
@@ -28,16 +28,16 @@
     max-width: 80%;
     padding: 20px;
 }
-.modal-backdrop {
+.survey-modal-backdrop {
     display: table-cell;
-    vertical-align: middle;
+    vertical-align: top;
     text-align: center;
     background-color: rgba(0, 0, 0, .5);
 }
 
 /*base styling*/
 
-.modal-inner {
+.survey-modal-inner {
     display: inline-block;
     text-align: left;
     background-color: #eee;
@@ -45,10 +45,10 @@
     padding: 20px;
 }
 
-.modal-link {
+.survey-modal-link {
   text-align: right;
 }
-#close-modal {
+#close-survey-modal {
     position: absolute;
     right: 10px;
     top: 10px;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -17,16 +17,16 @@
                 survey. The information provided will remain anonymous.
             </p>
             <h2>
-                <a class="btn btn-lg btn-success modal-link" target="_blank" href="https://kentonh.typeform.com/to/SNdj46">
+                <a class="btn btn-lg btn-success survey-modal-link" target="_blank" href="https://kentonh.typeform.com/to/SNdj46">
                     Individuals Participate >>>>
                 </a>
-                <a class="btn btn-lg btn-success modal-link" target="_blank" href="https://form.jotform.com/81908941084160">Employers Participate >>>></a>
+                <a class="btn btn-lg btn-success survey-modal-link" target="_blank" href="https://form.jotform.com/81908941084160">Employers Participate >>>></a>
 
             </h2>
         `;
 
         //create modal instance and pass in child elements
-            //can be whatever, styled however you want
+        //can be whatever, styled however you want
         var modal = new Modal(child, true);
         modal.show(); //open the modal window
     }

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -12,9 +12,9 @@ var Modal = function(child, strictClose) {
 Modal.prototype.show = function() {
     if (!this.portal) {
         this.portal = document.createElement('div');
-        this.portal.className = 'modal fade';
+        this.portal.className = 'survey-modal fade';
         var backdrop = document.createElement('div');
-            backdrop.className = 'modal-backdrop';
+            backdrop.className = 'survey-modal-backdrop';
             backdrop.addEventListener('click', this.hide.bind(this));
         this.portal.appendChild(backdrop);
         document.body.insertBefore(this.portal, document.body.children[0]);
@@ -29,9 +29,9 @@ Modal.prototype.render = function() {
             this.portal.classList.add('in');
         }.bind(this), 10);
         var inner = document.createElement('div');
-            inner.className = 'modal-inner';
+            inner.className = 'survey-modal-inner';
         var closeModal = document.createElement('div');
-            closeModal.id = 'close-modal';
+            closeModal.id = 'close-survey-modal';
             closeModal.className = 'fa fa-times';
         inner.appendChild(closeModal);
         inner.appendChild(this.child);
@@ -46,10 +46,10 @@ Modal.prototype.settleOnMount = function() {
 };
 
 Modal.prototype.hide = function(e) {
-    if (e.target.className === 'modal-backdrop' && !this.strictClose) {
+    if (e.target.className === 'survey-modal-backdrop' && !this.strictClose) {
         this.unmount();
     }
-    if (e.target.id === 'close-modal') {
+    if (e.target.id === 'close-survey-modal') {
         this.unmount();
     }
 };


### PR DESCRIPTION
Obligatory "first pull request". Let me know if I need to do anything to get this merged.

Several CSS classes were introduced for the dev survey modal that shadow the
bootstrap CSS modals used by the mentors page.

Normally the bootstrap modal class has a default "display" property of "none"
but the new modal class had a default "display" property of "table". This
caused the modal overlay to permanently be a part of the DOM with a Z-index
that "covered" the entire page.

This commit namespaces these new CSS classes to prevent this.

---

## Testing:

Done the old fashioned way. Manual. I believe I hit all the content, but I
would appreciate if someone else checked as well.

Testing Environment:

```
$ hugo version
Hugo Static Site Generator v0.46 linux/amd64 BuildDate: 2018-08-01T09:00:55Z
```
```
Chrome: Version 67.0.3396.99 (Offizieller Build) (64-Bit
```
---

## Alternatives Considered:

I considered updating the dev survey modal to use the bootstrap modal
infrastructure, but decided against it primarily because the dev survey modal
will be a temporary addition. My opinion is that it is much simpler to modify
the existing implementation, rather than update the entire approach -- just to
rip it all out once the survey is completed.

---

## Future Considerations:

Use existing bootstrap modal infrastructure. It looks like bootstrap is
already wired in the project. Both the CSS and JS artifacts are included the
header and footer partials found under:

 * `layouts/partials/head.html`
 * `layouts/partials/footer.html`

---

## Discovery Method:

Discovered using `git bisect`. Took a stab at finding a good commit, then
iterated until the "bad" commit was found

```
# git bisect start <bad> <good>
git bisect start master 2bea9c7efbdae04baba4d7a7233bd4a6ba821808
```

```
Introduced with:
commit 5ee6fdae43d74aad708bee8b31f138bc70d6a9e0
    Add modal for 2018 Salary Survey (#99)
```