### PR TITLE
Remove code to call piwik now that ChrisL8 is no longer hosting Piwik.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -30,18 +30,3 @@
 <meta name="theme-color" content="#eb7e32">
 
 <title> {{ .Title }} &middot; {{ .Site.Title }} </title>
-<!-- Piwik -->
-<script type="text/javascript">
-  var _paq = _paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//devict-piwik.ekpyroticfrood.net/";
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', '1']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Piwik Code -->


### PR DESCRIPTION
I shut down my Piwik site as it did not seem worth the expense and time to keep it updated.

The site is still making a failed call to it on every page hit. This will stop that.

This should be an exact revert of this pull request that added it in the first place:

https://github.com/devict/devict.org/pull/87/commits/2bcff25476a81cf6c9a32d3c750e727f4141bce8