### PR TITLE
fix: Update Logos for Twitter, Slack, and Meetup

### DIFF
--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -35,7 +35,7 @@ title: Home
           <p>Members of devICT have one common goal: to be better at what we do. Our events and services are aimed at achieving that.</p>
           <p>To make that happen we have monthly events that are both social and educational.</p>
           <p>We also have an active <a href="https://slack.devict.org" title="devICT Slack Signup">Slack community</a> which serves as a place to connect and discuss with others in the community.</p>
-          <p><a class="btn btn-lg btn-primary" href="https://meetup.com/devict" title="devICT Events"><i class="fa fa-calendar" aria-hidden="true"></i>View all of our events</a></p>
+          <p><a class="btn btn-lg btn-primary" href="https://meetup.com/devict" title="devICT Events"><i class="fa-brands fa-meetup icon-margin" aria-hidden="true"></i>View all of our events</a></p>
         </div>
 
         <div class="col-md-4">
@@ -47,7 +47,7 @@ title: Home
           <p>Most of the time we are hanging out in <a href="https://devict.slack.com" title="devICT Slack">Slack</a>. To join, just <a href="https://slack.devict.org" title="devICT Slack Registration" aria-label="devICT Slack registration form">fill out this form</a>.</p>
           <p>Primarily, be sure to <a href="https://www.meetup.com/devict" title="devICT on Meetup">become a member on the Meetup page</a>. Then you will receive notifications for upcoming events.</p>
           <p>You could also give a talk! Share the knowledge! We enjoy learning about any development related topics. Contact <a href="/about" title="About devICT">a board member</a> if you are interested!</p>
-          <p><a href="https://slack.devict.org" title="devICT Slack Registration" class="btn btn-lg btn-primary" aria-label="devICT Slack registration form"><i class="fa fa-slack" aria-hidden="true"></i>Come hang out with us!</a></p>
+          <p><a href="https://slack.devict.org" title="devICT Slack Registration" class="btn btn-lg btn-primary" aria-label="devICT Slack registration form"><i class="fa-brands fa-slack icon-margin" aria-hidden="true"></i>Come hang out with us!</a></p>
         </div>
       </div>
     </div>

--- a/_includes/partials/footer.njk
+++ b/_includes/partials/footer.njk
@@ -6,29 +6,27 @@
       </div>
       <div class="col-xs-12 col-sm-6 pull-right text-right">
         <a href="https://twitter.com/dev_ict" aria-label="Follow devICT on Twitter">
-          <i class="fa fa-twitter-square fa-4x" aria-hidden="true"></i>
+          <i class="fa-brands fa-x-twitter fa-3x  icon-margin" aria-hidden="true"></i>
         </a>
         <a href="https://github.com/devict" aria-label="See devICT projects on Github">
-          <i class="fa fa-github-square fa-4x" aria-hidden="true"></i>
+          <i class="fa-brands fa-github fa-3x icon-margin" aria-hidden="true"></i>
         </a>
         <a href="https://www.facebook.com/developerict" aria-label="Connect with devICT on Facebook">
-          <i class="fa fa-facebook-square fa-4x" aria-hidden="true"></i>
+          <i class="fa-brands fa-facebook fa-3x icon-margin" aria-hidden="true"></i>
         </a>
-        <a class="rounded" href="https://meetup.com/devict" aria-label="Find devICT events on Meetup">
-            <span class="fa-stack fa-2x">
-              <i class="fa fa-square fa-stack-2x" aria-hidden="true"></i>
-              <i class="fa fa-calendar fa-stack-1x fa-inverse" aria-hidden="true"></i>
-            </span>
+        <a href="https://meetup.com/devict" aria-label="Find devICT events on Meetup">
+          <i class="fa-brands fa-meetup fa-3x icon-margin" aria-hidden="true"></i>
         </a>
       </div>
-     </div>
+    </div>
     <div class="row">
       <div class="col-xs-12 col-sm-6 pull-right text-right">
         <a href="/report/" >Report a Code of Conduct Incident</a>
       </div>
-     </div>
+    </div>
   </div>
 </footer>
+
 
 <!-- jQuery! -->
 <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>

--- a/_includes/partials/head.njk
+++ b/_includes/partials/head.njk
@@ -10,6 +10,7 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css" integrity="sha384-fLW2N01lMqjakBkx3l/M9EahuwpSfeNvV63J5ezn3uZzapT0u7EYsXMjQV+0En5r" crossorigin="anonymous">
 <!-- Font Awesome! -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" crossorigin="anonymous">
 
 <!-- Fonts! -->
 <link href="https://fonts.googleapis.com/css?family=Hind:400,700|Oswald" rel="stylesheet">

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -375,3 +375,8 @@ h2 .fa {
 .leadership .figure {
   margin-bottom: 2em;
 }
+
+.icon-margin {
+  margin-right: 8px; 
+}
+


### PR DESCRIPTION
This pull request aims to update the outdated Twitter logo, as well as correct the incorrect logos for Slack and Meetup in our project. Outdated and incorrect logos can affect the overall user experience and brand representation, so it's crucial to keep them up to date.

Changes Made
1. Twitter Logo Update: Replaced the old, outdated Twitter logo with the latest version provided by Twitter's official branding guidelines. The updated logo ensures that our project remains aligned with Twitter's branding standards.

2. Slack Logo Correction: Corrected the Slack logo to match the official Slack logo provided in the Slack branding guidelines. The previous logo did not adhere to Slack's brand guidelines.

3. Meetup Logo Correction: Corrected the Meetup logo to match the official Meetup logo provided in Meetup's branding guidelines. The previous logo was incorrect and didn't accurately represent Meetup's branding.

![Screenshot 2023-10-25 220552](https://github.com/devict/devict.org/assets/85775976/594466f1-da48-43d8-86b6-7b14bd63958f)

#162
